### PR TITLE
Missing ply

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,13 +8,12 @@ dist: xenial
 sudo: true
 # Command to install dependencies
 install:
-  - pip install -r requirements.txt
+  - python setup.py install
   - pip install --upgrade pytest 
   - pip install -r dev-requirements.txt
 # Command to run tests
 script:
   - py.test -s --cov-report=xml --cov
-  - python setup.py install
 # Command after success
 after_success:
   - python-codacy-coverage -r coverage.xml

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,1 @@
-requests
-pyyaml
-enum34
-ply
+.

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,8 @@ setup(name = 'autoremove-torrents',
     install_requires = [
         'requests',
         'pyyaml',
-        'enum34'
+        'enum34',
+        'ply'
     ],
     entry_points = {
         'console_scripts':[


### PR DESCRIPTION
The script `setup.py` miss the dependence `ply`. It will cause `ModuleNotFoundError` when we're using the `remove` condition.