### PR TITLE
transmission 任务添加后 无活动时,活动时间为0 (1970.1.1.0.0.0啥的)  使用 action: remove-inactive-seeds 会导致 误删除

### DIFF
--- a/autoremovetorrents/client/transmission.py
+++ b/autoremovetorrents/client/transmission.py
@@ -1,5 +1,6 @@
 #-*- coding:utf-8 -*-
 import requests
+import time
 from ..torrent import Torrent
 from ..clientstatus import ClientStatus
 from ..torrentstatus import TorrentStatus
@@ -150,7 +151,7 @@ class Transmission(object):
         torrent_obj.connected_seeder = torrent['peersSendingToUs']
         torrent_obj.leecher = sum([tracker['leecherCount'] for tracker in torrent['trackerStats']])
         torrent_obj.connected_leecher = torrent['peersGettingFromUs']
-        torrent_obj.last_activity = torrent['activityDate']
+        torrent_obj.last_activity = torrent['activityDate'] if torrent['activityDate'] !=0 else time.time()
         torrent_obj.average_upload_speed = torrent['uploadedEver'] / torrent['secondsSeeding'] if torrent['secondsSeeding'] != 0 else 0
         torrent_obj.average_download_speed = torrent['downloadedEver'] / torrent['secondsDownloading'] if torrent['secondsDownloading'] != 0 else 0
         torrent_obj.progress = torrent['percentDone']


### PR DESCRIPTION
transmission 任务添加后 无活动时,活动时间为0 (1970.1.1.0.0.0啥的)  使用 action: remove-inactive-seeds 会导致误删除
加了个判断,如果 活动时间为 0 则为当前时间 以免误删