### PR TITLE
Update sortbase.py

### DIFF
--- a/autoremovetorrents/condition/sortbase.py
+++ b/autoremovetorrents/condition/sortbase.py
@@ -14,7 +14,8 @@ class ConditionWithSort(Condition):
             'remove-big-seeds': {'key':lambda torrent: torrent.size, 'reverse':True},
             'remove-small-seeds': {'key':lambda torrent: torrent.size, 'reverse':False},
             'remove-active-seeds': {'key':lambda torrent: torrent.last_activity, 'reverse':True},
-            'remove-inactive-seeds': {'key':lambda torrent: torrent.last_activity, 'reverse':False}
+            'remove-inactive-seeds': {'key':lambda torrent: torrent.last_activity, 'reverse':False},
+            'remove-slow-upload-seeds': {'key':lambda torrent: torrent.upload_speed, 'reverse':False}
         }
         if self._action in handlers.keys():
             torrents.sort(key=handlers[self._action]['key'], reverse=handlers[self._action]['reverse'])


### PR DESCRIPTION
Add 'remove-slow-upload-seeds' to 'action' keyword in order to remove torrents with slower upload speed.
添加'remove-slow-upload-seeds'到'action'关键字, 从而能够删除慢速上传的种子.

Example:
limit_max_torrents:
status:
- downloading
maximum_number:
limit: 30
action: remove-slow-upload-seeds