### PR TITLE
Fix broken `delete_torrents` on qbittorrent 4.5.0+

### DIFF
--- a/autoremovetorrents/client/qbittorrent.py
+++ b/autoremovetorrents/client/qbittorrent.py
@@ -110,11 +110,11 @@ class qBittorrent(object):
         
         # Batch Delete torrents
         def delete_torrents(self, torrent_hash_list):
-            return self._session.get(self._host+'/api/v2/torrents/delete', params={'hashes':'|'.join(torrent_hash_list), 'deleteFiles': False})
+            return self._session.post(self._host+'/api/v2/torrents/delete', params={'hashes':'|'.join(torrent_hash_list), 'deleteFiles': False})
         
         # Batch Delete torrents and data
         def delete_torrents_and_data(self, torrent_hash_list):
-            return self._session.get(self._host+'/api/v2/torrents/delete', params={'hashes':'|'.join(torrent_hash_list), 'deleteFiles': True})
+            return self._session.post(self._host+'/api/v2/torrents/delete', params={'hashes':'|'.join(torrent_hash_list), 'deleteFiles': True})
 
     def __init__(self, host):
         # Logger

--- a/autoremovetorrents/client/qbittorrent.py
+++ b/autoremovetorrents/client/qbittorrent.py
@@ -110,11 +110,11 @@ class qBittorrent(object):
         
         # Batch Delete torrents
         def delete_torrents(self, torrent_hash_list):
-            return self._session.post(self._host+'/api/v2/torrents/delete', params={'hashes':'|'.join(torrent_hash_list), 'deleteFiles': False})
+            return self._session.post(self._host+'/api/v2/torrents/delete', data={'hashes':'|'.join(torrent_hash_list), 'deleteFiles': False})
         
         # Batch Delete torrents and data
         def delete_torrents_and_data(self, torrent_hash_list):
-            return self._session.post(self._host+'/api/v2/torrents/delete', params={'hashes':'|'.join(torrent_hash_list), 'deleteFiles': True})
+            return self._session.post(self._host+'/api/v2/torrents/delete', data={'hashes':'|'.join(torrent_hash_list), 'deleteFiles': True})
 
     def __init__(self, host):
         # Logger


### PR DESCRIPTION
qbittorrent did not update their official web API doc, but according to the discussion in [qBittorrent/issues/18097](https://github.com/qbittorrent/qBittorrent/issues/18097), I changed the GET method to POST.
Test pass in Unraid 6.11, qbittorrent 4.5.2, python 3.8.5.