### PR TITLE
Add remove condition for hard links

### DIFF
--- a/autoremovetorrents/client/qbittorrent.py
+++ b/autoremovetorrents/client/qbittorrent.py
@@ -210,6 +210,7 @@ class qBittorrent(object):
                 torrent_obj.stalled = torrent['state'] == 'stalledUP' or torrent['state'] == 'stalledDL'
                 torrent_obj.size = torrent['size']
                 torrent_obj.ratio = torrent['ratio']
+                torrent_obj.content_path = torrent['content_path']
                 torrent_obj.uploaded = properties['total_uploaded']
                 torrent_obj.downloaded = properties['total_downloaded']
                 torrent_obj.create_time = properties['addition_date']

--- a/autoremovetorrents/condition/hardlink.py
+++ b/autoremovetorrents/condition/hardlink.py
@@ -1,0 +1,24 @@
+#-*- coding:utf-8 -*-
+import os
+from .base import Comparer
+from .base import Condition
+from ..torrentstatus import TorrentStatus
+
+class HardLinkCondition(Condition):
+    def __init__(self, r, comp = Comparer.GT):
+        Condition.__init__(self) # Initialize remain and remove list
+        self._hardlink = r
+        self._comparer = comp
+
+    def apply(self, client_status, torrents):
+        for torrent in torrents:
+            hardlinks = sum(
+                os.stat(os.path.join(root, file)).st_nlink - 1
+                for root, _, files in os.walk(torrent.content_path)
+                for file in files
+                if os.stat(os.path.join(root, file)).st_nlink > 1
+            )
+            if self.compare(hardlinks, self._hardlink, self._comparer):
+                self.remove.add(torrent)
+            else:
+                self.remain.add(torrent)

--- a/autoremovetorrents/conditionparser.py
+++ b/autoremovetorrents/conditionparser.py
@@ -19,6 +19,7 @@ from .condition.size import SizeCondition
 from .condition.uploaded import UploadsCondition
 from .condition.uploadratio import UploadRatioCondition
 from .condition.uploadspeed import UploadSpeedCondition
+from .condition.hardlink import HardLinkCondition
 from .conditionlexer import ConditionLexer
 from .exception.nosuchcondition import NoSuchCondition
 from .exception.syntaxerror import ConditionSyntaxError
@@ -44,6 +45,7 @@ class ConditionParser(object):
         'upload': UploadsCondition,
         'upload_ratio': UploadRatioCondition,
         'upload_speed': UploadSpeedCondition,
+        'hard_link': HardLinkCondition,
     }
 
     # Condition expression

--- a/autoremovetorrents/strategy.py
+++ b/autoremovetorrents/strategy.py
@@ -23,6 +23,7 @@ from .condition.torrentsize import TorrentSizeCondition
 from .condition.uploaded import UploadsCondition
 from .condition.uploadratio import UploadRatioCondition
 from .condition.uploadspeed import UploadSpeedCondition
+from .condition.hardlink import HardLinkCondition
 from .conditionparser import ConditionParser
 from .exception.unsupportedproperty import UnsupportedProperty
 from .filter.category import CategoryFilter
@@ -131,6 +132,7 @@ class Strategy(object):
             'downloading_time': DownloadingTimeCondition,
             'max_size': SizeCondition,
             'upload_ratio': UploadRatioCondition,
+            'hard_link': HardLinkCondition,
         }
         for conf in self._conf:
             if conf in conditions:

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -341,6 +341,10 @@ The first 18 conditions are here. In order to avoid torrents being mistakenly de
      - 
      - All
      - The maximum upload ratio. Note that the upload ratio here is different from the ratio. For each torrent, the upload ratio is ``uploaded size`` divided by its ``size``.
+   * - ``hard_link``
+     - 
+     - All
+     - The total maximum hard links in the content path.
 
 .. note::
 


### PR DESCRIPTION
Hi,

This will calculate the total hardlinks from the content_path where the files reside. It calculates from all files in the folder and sub folders and gives a number.

for example to let it remove when having 0 links:

> remove: hard_link < 1

recommend needs more testing first, hence the draft pull

https://github.com/jerrymakesjelly/autoremove-torrents/issues/146