### PR TITLE
Add Discord webhook notifications

### DIFF
--- a/autoremovetorrents/task.py
+++ b/autoremovetorrents/task.py
@@ -129,7 +129,6 @@ class Task(object):
                 else 'The torrent %s has been removed.',
                 delete_list[hash_]
             )
-
             if self._webhook is not None:
                 fields = [
                     {
@@ -138,13 +137,11 @@ class Task(object):
                     }
                 ]
                 self.send_webhook("Torrent Deleted Successfully", 5091684, fields)
-            
         for torrent in failed:
             self._logger.error('The torrent %s and its data cannot be removed. Reason: %s' if self._delete_data \
                 else 'The torrent %s cannot be removed. Reason: %s',
                 delete_list[torrent['hash']], torrent['reason']
             )
-
             if self._webhook is not None:
                 fields = [
                     {

--- a/autoremovetorrents/util/discord_webhook_handler.py
+++ b/autoremovetorrents/util/discord_webhook_handler.py
@@ -1,0 +1,66 @@
+# -*- coding:utf-8 -*-
+import requests
+from .. import logger
+
+class DiscordWebhookHandler:
+    def __init__(self, name, webhook_url, client_name):
+        # Logger
+        self._logger = logger.Logger.register(__name__)
+
+        # Settings
+        self._task_name = name
+        self._webhook = webhook_url
+        self._client_name = client_name
+
+        # Log creation
+        self._logger.debug('Webhook handler for task %s created with url %s', self._task_name, self._webhook)
+
+    # Send a webhook when torrent deletion is successful
+    def send_success(self, torrent):
+        self._logger.info("Sending success webhook for torrent: %s", torrent)
+        fields = [
+            {
+                "name": "Torrent",
+                "value": torrent
+            }
+        ]
+        self.send_webhook("Torrent Deleted Successfully", 5091684, fields)
+
+    # Send a webhook when torrent deletion fails
+    def send_failure(self, torrent, reason):
+        self._logger.info("Sending failure webhook for torrent %s with reason: %s", torrent, reason)
+        fields = [
+            {
+                "name": "Torrent",
+                "value": torrent
+            },
+            {
+                "name": "Reason",
+                "value": reason
+            }
+        ]
+        self.send_webhook("Torrent Deletion Failed", 11619684, fields)
+
+    # Send a webhook with discord embed format
+    def send_webhook(self, title, color, fields):
+        payload = {
+            "username": "autoremove-torrents",
+            "embeds": [
+                {
+                    "author": {
+                        "name": self._client_name,
+                    },
+                    "title": title,
+                    "color": color,
+                    "fields": 
+                        fields
+                }
+            ]
+        }
+        result = requests.post(self._webhook, json=payload, headers={"Content-Type": "application/json"}, timeout=10)
+        try:
+            result.raise_for_status()
+        except requests.exceptions.HTTPError as err:
+            self._logger.error("Failed to deliver webhook: %s", err)
+        else:
+            self._logger.info("Webhook delivered successfully with status code %s.", result.status_code)

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -55,10 +55,10 @@ Just name your task.
    No spaces are allowed before the task name.
 
 
-Part 2: Login Information
+Part 2: Login Information and Webhook URL
 -------------------------
 
-This part is your login inforamtion.
+This part is your login information and optionally a Discord Webhook URL.
 
 For qBittorrent, Transmission or μTorrent
 ++++++++++++++++++++++++++++++++++++++++++
@@ -80,6 +80,13 @@ This program accesses Deluge via its RPC protocol.
 * ``username``: The username of the Deluge Daemon.
 * ``password``: The password of the Deluge Daemon.
 
+Discord Webhook (Optional)
++++++++++++
+
+If you want to receive notifications via Discord Webhook, you can add the following fields:
+
+* ``webhook``: The URL of your Discord Webhook. For example, ``https://discord.com/api/webhooks/123456789/abcdefghijklmnopqrstuvwxyz``.
+
 Example:
 
 .. code-block:: yaml
@@ -89,6 +96,7 @@ Example:
      host: 127.0.0.1:58846
      username: localclient
      password: 357a0d23f09b9f303f58846e41986b36fef2ac88
+     webhook: "https://discord.com/api/webhooks/123456789/abcdefghijklmnopqrstuvwxyz" # Optional
 
 .. note::
 


### PR DESCRIPTION
This PR adds very barebones webhook functionality, it was getting hard to keep track of when one of a few hundred torrents was removed.
Currently the embed style is for discord as this is what I use, if this is something that is wanted more can be added or modified if it should be handled elsewhere.
Webhook url is just a `webhook` string next to the login information.

mentioned in #108